### PR TITLE
bump shovel to 4143

### DIFF
--- a/shovel/Dockerfile
+++ b/shovel/Dockerfile
@@ -1,3 +1,4 @@
-FROM indexsupply/shovel:1.6
+# Commit-tagged image (indexsupply/shovel@414382aa, 2026-01-11) — no release tags after 1.6.
+FROM indexsupply/shovel:4143
 COPY config.json .
 CMD shovel -config config.json -l :$PORT


### PR DESCRIPTION
Bumps the shovel Docker image from `1.6` (May 2024, last tagged release) to `4143`, the commit-tagged image for the current tip of shovel `main` ([`414382aa`](https://github.com/indexsupply/shovel/commit/414382aaa0d5), Jan 2026). Index Supply stopped tagging releases after 1.6, so commit-tagged images are the only way to get fixes.

Notable fixes picked up:
- reorg Postgres transaction bug + increased reorg depth limit (Nov 2024)
- panic on events with empty inputs (Sept 2025)
- empty `bytea` stored instead of NULL (June 2024)

Verified locally: built the image, ran it against a throwaway Postgres with public RPCs — config parses unchanged, all 7 chain tasks start, `files_created` schema matches production shape, and it indexed a real `FileCreated` event from Zora.

First step of consolidating indexing onto shovel (next: move frontend off ponder, then delete ponder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)