### PR TITLE
move frontend off ponder, onto shovel

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,8 +11,6 @@
   "dependencies": {
     "@ethfs/contracts": "workspace:*",
     "@ethfs/deploy": "workspace:*",
-    "@ethfs/ponder": "workspace:*",
-    "@ponder/client": "0.9.0-next.10",
     "@rainbow-me/rainbowkit": "^2.2.4",
     "@tanstack/react-query": "^5.66.9",
     "fflate": "^0.7.4",

--- a/packages/web/src/file-explorer/FileExplorer.tsx
+++ b/packages/web/src/file-explorer/FileExplorer.tsx
@@ -33,9 +33,7 @@ export function FileExplorer() {
     queryKey: ["files", chain.id, searchQuery],
     queryFn: async () => {
       return fetch(
-        `${process.env.NEXT_PUBLIC_PONDER_URL}/api/${
-          chain.id
-        }/files?${new URLSearchParams({
+        `/api/${chain.id}/files?${new URLSearchParams({
           filename: searchQuery,
         })}`,
       ).then((res) => res.json() as Promise<OnchainFile[]>);

--- a/packages/web/src/ponder.ts
+++ b/packages/web/src/ponder.ts
@@ -1,8 +1,0 @@
-import * as schema from "@ethfs/ponder/ponder.schema";
-import { createClient } from "@ponder/client";
-
-// TODO: env
-export const ponder = createClient(process.env.NEXT_PUBLIC_PONDER_URL!, {
-  schema,
-});
-export { schema };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,12 +134,6 @@ importers:
       '@ethfs/deploy':
         specifier: workspace:*
         version: link:../deploy
-      '@ethfs/ponder':
-        specifier: workspace:*
-        version: link:../ponder
-      '@ponder/client':
-        specifier: 0.9.0-next.10
-        version: 0.9.0-next.10(@electric-sql/pglite@0.2.16)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(kysely@0.27.5)(pg@8.13.1)(postgres@3.4.5)(react@18.3.1)(typescript@5.7.3)
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.4
         version: 2.2.4(@tanstack/react-query@5.66.9(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.23.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.14.12(@tanstack/query-core@5.66.4)(@tanstack/react-query@5.66.9(react@18.3.1))(@types/react@18.3.18)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.23.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
@@ -266,9 +260,6 @@ packages:
 
   '@electric-sql/pglite@0.2.13':
     resolution: {integrity: sha512-YRY806NnScVqa21/1L1vaysSQ+0/cAva50z7vlwzaGiBOTS9JhdzIRHN0KfgMhobFAphbznZJ7urMso4RtMBIQ==}
-
-  '@electric-sql/pglite@0.2.16':
-    resolution: {integrity: sha512-dCSHpoOKuTxecaYhWDRp2yFTN3XWcMPMrBVl5yOR8VZEUprz4+R3iuU7BipmlsqBnBDO/6l9H/C2ZwJdunkWyw==}
 
   '@emotion/hash@0.9.2':
     resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
@@ -948,14 +939,6 @@ packages:
   '@pnpm/npm-conf@2.2.2':
     resolution: {integrity: sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==}
     engines: {node: '>=12'}
-
-  '@ponder/client@0.9.0-next.10':
-    resolution: {integrity: sha512-BgVbYZ3A0AGH2pBjUBqYiySmmZxImF8mg4x7BGT2t7DtFvolO5SHBYL/ABvZ1vXEXSrZSmZxEoRgYoKzS+hrHA==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@ponder/utils@0.2.3':
     resolution: {integrity: sha512-QdlRXrn48nRM/QxNHRffO3PnIFvUf9qHE+rXSut44r74E4iiq9UrIPMhSMyCbJN68yU4QyTupZ/qpqE5PNAo8A==}
@@ -3403,10 +3386,6 @@ packages:
     resolution: {integrity: sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw==}
     engines: {node: '>=14.0.0'}
 
-  kysely@0.27.5:
-    resolution: {integrity: sha512-s7hZHcQeSNKpzCkHRm8yA+0JPLjncSWnjb+2TIElwS2JAqYr+Kv3Ess+9KFfJS0C1xcQ1i9NkNHpWwCYpHMWsA==}
-    engines: {node: '>=14.0.0'}
-
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -4777,10 +4756,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@7.3.0:
-    resolution: {integrity: sha512-Qy96NND4Dou5jKoSJ2gm8ax8AJM/Ey9o9mz7KN1bb9GP+G0l20Zw8afxTnY2f4b7hmhn/z8aC2kfArVQlAhFBw==}
-    engines: {node: '>=20.18.1'}
-
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
 
@@ -5275,9 +5250,6 @@ snapshots:
       '@noble/ciphers': 1.2.0
 
   '@electric-sql/pglite@0.2.13': {}
-
-  '@electric-sql/pglite@0.2.16':
-    optional: true
 
   '@emotion/hash@0.9.2': {}
 
@@ -5961,43 +5933,6 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
-
-  '@ponder/client@0.9.0-next.10(@electric-sql/pglite@0.2.16)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(kysely@0.27.5)(pg@8.13.1)(postgres@3.4.5)(react@18.3.1)(typescript@5.7.3)':
-    dependencies:
-      drizzle-orm: 0.36.4(@electric-sql/pglite@0.2.16)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(kysely@0.27.5)(pg@8.13.1)(postgres@3.4.5)(react@18.3.1)
-      undici: 7.3.0
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/react'
-      - '@types/sql.js'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bun-types
-      - expo-sqlite
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - postgres
-      - prisma
-      - react
-      - sql.js
-      - sqlite3
 
   '@ponder/utils@0.2.3(typescript@5.7.3)(viem@2.22.17(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(zod@3.24.1))':
     dependencies:
@@ -7537,16 +7472,6 @@ snapshots:
       postgres: 3.4.5
       react: 18.2.0
 
-  drizzle-orm@0.36.4(@electric-sql/pglite@0.2.16)(@opentelemetry/api@1.9.0)(@types/react@18.3.18)(kysely@0.27.5)(pg@8.13.1)(postgres@3.4.5)(react@18.3.1):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.2.16
-      '@opentelemetry/api': 1.9.0
-      '@types/react': 18.3.18
-      kysely: 0.27.5
-      pg: 8.13.1
-      postgres: 3.4.5
-      react: 18.3.1
-
   dset@3.1.4: {}
 
   dunder-proto@1.0.1:
@@ -7931,7 +7856,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
@@ -7960,12 +7885,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.15.0
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.3
       get-tsconfig: 4.10.0
@@ -7977,14 +7902,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7999,7 +7924,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9016,9 +8941,6 @@ snapshots:
       - tedious
 
   kysely@0.26.3: {}
-
-  kysely@0.27.5:
-    optional: true
 
   language-subtag-registry@0.3.23: {}
 
@@ -10554,8 +10476,6 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
-
-  undici@7.3.0: {}
 
   unenv@1.10.0:
     dependencies:

--- a/render.yaml
+++ b/render.yaml
@@ -8,8 +8,6 @@ services:
     startCommand: pnpm start
     envVars:
       - fromGroup: EthFS RPCs
-      - key: NEXT_PUBLIC_PONDER_URL
-        value: https://ethfs.ponder-dev.com
       - key: DATABASE_URL
         fromDatabase:
           name: ethfs-shovel-db


### PR DESCRIPTION
Step 2 of consolidating indexing onto shovel (follows #46).

The file explorer was the only live ponder consumer, and it wasn't even using `@ponder/client` — it fetched `${NEXT_PUBLIC_PONDER_URL}/api/[chainId]/files` from the ponder service. The web app already serves an identical route (same `OnchainFile` shape, same Sepolia `gunzipScripts` metadata fix) backed by the shovel `files_created` table, so this just points the fetch at the app's own route.

- `FileExplorer.tsx`: fetch same-origin `/api/[chainId]/files` instead of the ponder service
- delete `src/ponder.ts` (dead code — nothing imported it)
- drop `@ethfs/ponder` + `@ponder/client` deps from web
- remove `NEXT_PUBLIC_PONDER_URL` from render.yaml

Verified: `pnpm build` passes; ran the dev server against the production shovel DB and confirmed `/api/1/files` (and filename search) returns current data with correct shape.

Note for local dev: the web app now needs `DATABASE_URL` in `packages/web/.env.local` (it's the commented-out first line) instead of a running ponder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)