### PR TITLE
pin foundry to v1.7.1 in contracts CI

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -39,9 +39,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.7.1
       - run: pnpm install
       - run: pnpm build
       - name: Outdated files detected, run `pnpm build` and commit them
@@ -78,8 +78,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.7.1
       - run: pnpm install
       - run: pnpm test


### PR DESCRIPTION
Contracts CI has been red on every push since March because it installs unpinned Foundry `nightly`: a recent nightly emits a synthetic `out/MockProject.t.sol/VmContractHelper50.abi.json` artifact during `forge build`, which trips the clean-tree-after-build check (the `50` is version-suffixed, so committing it would just break again on the next nightly).

Local forge `v1.7.1` (stable) produces a clean tree against the committed ABIs, so this pins CI to that same release — reproducible builds, and CI stops breaking on upstream nightly changes. Also updates the action to `foundry-rs/foundry-toolchain` (the `onbjerg` path is the old pre-move location).

The contracts run on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)